### PR TITLE
Update Report Calculation

### DIFF
--- a/src/Nagger.Services/TimeService.cs
+++ b/src/Nagger.Services/TimeService.cs
@@ -120,11 +120,11 @@
             var workThisWeek = GetSpanOfWorkSince(DayOfWeek.Sunday);
             var workToday = GetSpanOfWorkSince(DateTime.Today.DayOfWeek);
 
-            var hoursThisWeek = workThisWeek.Hours;
-            var minutesThisWeek = workThisWeek.Minutes;
+            var hoursThisWeek = Math.Truncate(workThisWeek.TotalHours);
+            var minutesThisWeek = (workThisWeek.TotalHours - hoursThisWeek) * 60;
 
-            var hoursToday = workToday.Hours;
-            var minutesToday = workToday.Minutes;
+            var hoursToday = Math.Truncate(workToday.TotalHours);
+            var minutesToday = (workToday.TotalHours - hoursToday) * 60;
 
             var builder = new StringBuilder();
             builder.AppendLine("---This Week---");

--- a/src/nagger.DotSettings
+++ b/src/nagger.DotSettings
@@ -1,4 +1,5 @@
 ﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpCodeStyle/DEFAULT_PRIVATE_MODIFIER/@EntryValue">Implicit</s:String>
 	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/EXPLICIT_PRIVATE_MODIFIER/@EntryValue">False</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EAddAccessorOwnerDeclarationBracesMigration/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EMigrateBlankLinesAroundFieldToBlankLinesAroundProperty/@EntryIndexedValue">True</s:Boolean>


### PR DESCRIPTION
When the number of hours spend exceeded 24 hours the `.Hours` property would reset. This resulted in incorrect time reporting.

This has been updated to take advantage of the `TotalHours` property.
