### PR TITLE
Check for associated repo before asking for task

### DIFF
--- a/src/Nagger.Services/Meazure/MeazureRunner.cs
+++ b/src/Nagger.Services/Meazure/MeazureRunner.cs
@@ -46,6 +46,9 @@
 
         public Task AskForAssociatedTask(Task currentTask)
         {
+            // only ask for an associated task if the project repository has an associated repository
+            if (currentTask.Project?.AssociatedRemoteRepository == null) return null;
+
             if (!_inputService.AskForBoolean("Associate this entry with an additional task?")) return null;
 
             Task associatedTask;


### PR DESCRIPTION
Currently an Associated Task is asked for even if the repo itself isn't configured with an associated repo. This fixes that by checking for an Associated Repo before asking about the task.